### PR TITLE
Commented out Redis line during testing

### DIFF
--- a/lib/connectHapiServerToRedis.js
+++ b/lib/connectHapiServerToRedis.js
@@ -46,7 +46,7 @@ function connectHapiServerToRedis (server, cb) {
         // From session get userid
         var rawSid = req.state['connect.sid.1.0'];
  
-        var sid = RedisSessionReader.unsignCookieSid(rawSid, secret);
+        //var sid = RedisSessionReader.unsignCookieSid(rawSid, secret);
         //RedisSessionReader.getSessionIdFromRedis(sessionId, server.plugins['hapi-redis'].client, function (err, userId) {
         //  if (err) {return cb(err);}
         //  cb(null, { userId: userId })


### PR DESCRIPTION
We're commenting out the Redis stuff for now during testing, but we forgot to comment out one of the lines, which was breaking the tests. I'm commenting it out here; later when we add actual Redis we can uncomment all these lines.
