### PR TITLE
Enable cookie name configuration

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -22,7 +22,12 @@ var rawSignedSessionId = 's%3AK-5uqkQChDuf5b5dAytqfqm8.dvl08QCN1ydR5TT7uul9v0B3e
 var sid = RedisSessionReader.unsignCookieSid(rawSignedSessionId, sessionSecret);
 console.log('querying for sid: ', sid);
 
-RedisSessionReader.connectHapiServerToRedis(server, _doStuffAfterConnectingToRedis);
+redisOptions = {
+  host: 'localhost',
+  port: 6379
+};
+
+RedisSessionReader.connectHapiServerToRedis(server, sessionSecret, 'connect.sid.1.0', redisOptions, _doStuffAfterConnectingToRedis);
 
 function _doStuffAfterConnectingToRedis (err, status) {
   if (err) {console.log(err); return;}

--- a/lib/connectHapiServerToRedis.js
+++ b/lib/connectHapiServerToRedis.js
@@ -36,7 +36,7 @@ authPlug.register.attributes = {
 // END PLUGIN code
 
 
-function connectHapiServerToRedis (server, secret, redisOptions, cb) {
+function connectHapiServerToRedis (server, secret, cookieName, redisOptions, cb) {
 
   // Register Plugin - inside redis-session-reader, in the connectHapiServerToRedis.js file
   server.register(authPlug, function(err) {
@@ -58,7 +58,7 @@ function connectHapiServerToRedis (server, secret, redisOptions, cb) {
 
         // Get cookie id
     
-        var rawSid = req.state['connect.sid.1.0'];
+        var rawSid = req.state[cookieName];
 
         if (!rawSid) {
           // Cookie does not exist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-session-reader",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Cookie name can now be specified when running connectHapiServerToRedis
